### PR TITLE
Enhance blog post theme styling with stronger CSS specificity

### DIFF
--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -46,6 +46,13 @@ body {
 body.cayman {
     background: #ffffff !important;
     color: #333333 !important;
+    --primary-color: #155799 !important;
+    --secondary-color: #159957 !important;
+    --bg-dark: #ffffff !important;
+    --bg-medium: #f5f5f5 !important;
+    --bg-light: #e9ecef !important;
+    --text-primary: #333333 !important;
+    --text-secondary: #606c71 !important;
 }
 
 body.cayman .navbar {
@@ -206,57 +213,61 @@ body.cayman .nav-link::after {
     display: inline-block;
 }
 
-.post-content h3 {
-    font-size: 1.4rem;
-    margin: 1.5rem 0 0.5rem 0;
-    color: var(--text-primary, #333);
+/* Additional specificity for Cayman theme overrides */
+html body.cayman .content {
+    background: #ffffff !important;
 }
 
-.post-content p {
-    margin-bottom: 1rem;
+html body.cayman .blog-post {
+    background: #ffffff !important;
 }
 
-.post-content code {
-    background: var(--bg-light, #f6f8fa);
-    padding: 0.2rem 0.4rem;
-    border-radius: 3px;
-    font-family: 'JetBrains Mono', monospace;
-    font-size: 0.9em;
+html body.cayman .post-content * {
+    color: #333333 !important;
 }
 
-.post-content pre {
-    background: var(--bg-light, #f6f8fa);
-    padding: 1rem;
-    border-radius: 6px;
-    overflow-x: auto;
-    margin: 1rem 0;
+html body.cayman .post-content h1,
+html body.cayman .post-content h2 {
+    color: #155799 !important;
 }
 
-.post-content pre code {
-    background: none;
-    padding: 0;
+html body.cayman .post-content h3,
+html body.cayman .post-content h4,
+html body.cayman .post-content h5,
+html body.cayman .post-content h6 {
+    color: #333333 !important;
 }
 
-.post-tags {
-    margin: 2rem 0;
-    padding: 1rem 0;
-    border-top: 1px solid var(--bg-light, #e2e8f0);
+html body.cayman .post-content strong {
+    color: #155799 !important;
 }
 
-.post-tags h4 {
-    margin-bottom: 0.5rem;
-    color: var(--text-primary, #333);
+html body.cayman .post-content a {
+    color: #155799 !important;
 }
 
-.post-tags .tag {
-    background: var(--bg-light, #f6f8fa);
-    color: var(--primary-color, #0366d6);
-    padding: 0.3rem 0.8rem;
-    border-radius: 20px;
-    font-size: 0.9rem;
-    margin-right: 0.5rem;
-    margin-bottom: 0.5rem;
-    display: inline-block;
+html body.cayman .post-content a:hover {
+    color: #159957 !important;
+}
+
+html body.cayman .post-content code {
+    background: #f6f8fa !important;
+    color: #333333 !important;
+}
+
+html body.cayman .post-content pre {
+    background: #f6f8fa !important;
+    border: 1px solid #e9ecef !important;
+}
+
+html body.cayman .post-content pre code {
+    background: none !important;
+    color: #333333 !important;
+}
+
+html body.cayman .post-tags .tag {
+    background: #e9ecef !important;
+    color: #155799 !important;
 }
 
 @media (max-width: 768px) {


### PR DESCRIPTION
## Summary
- Add CSS variable overrides for Cayman theme on blog posts
- Increase CSS specificity to override dark theme styles  
- Remove duplicate CSS rules that were causing conflicts
- Ensure all blog post content displays with proper Cayman theme colors

## Changes Made
- Added Cayman theme CSS variables directly to body.cayman selector
- Used `html body.cayman` selectors for higher specificity than base styles
- Cleaned up conflicting CSS rules that were causing theme issues
- Added comprehensive overrides for headers, links, code blocks, and tags

## Test plan
- [ ] Verify individual blog posts now display with proper Cayman theme styling
- [ ] Verify white background and dark text on blog post pages
- [ ] Verify navigation and header styling consistency
- [ ] Verify code blocks and links display correctly

🤖 Generated with [Claude Code](https://claude.ai/code)