### PR TITLE
Fix blog page background and complete Cayman theme implementation

### DIFF
--- a/_includes/blog-sidebar.html
+++ b/_includes/blog-sidebar.html
@@ -178,6 +178,50 @@
     font-size: 0.9rem;
 }
 
+/* Cayman theme overrides for sidebar */
+body.cayman .blog-sidebar {
+    background: #f8f9fa !important;
+}
+
+body.cayman .sidebar-section h3 {
+    color: #155799 !important;
+    border-bottom-color: #155799 !important;
+}
+
+body.cayman .recent-posts a,
+body.cayman .categories a,
+body.cayman .archive a {
+    color: #333333 !important;
+}
+
+body.cayman .recent-posts a:hover,
+body.cayman .categories a:hover,
+body.cayman .archive a:hover {
+    color: #155799 !important;
+}
+
+body.cayman .recent-posts time {
+    color: #606c71 !important;
+}
+
+body.cayman .no-posts {
+    color: #606c71 !important;
+}
+
+body.cayman .tag-link {
+    background: #e2e8f0 !important;
+    color: #333333 !important;
+}
+
+body.cayman .tag-link:hover {
+    background: #155799 !important;
+    color: white !important;
+}
+
+body.cayman .sidebar-about {
+    color: #606c71 !important;
+}
+
 @media (max-width: 768px) {
     .blog-sidebar {
         margin-top: 2rem;

--- a/_includes/navigation.html
+++ b/_includes/navigation.html
@@ -8,6 +8,7 @@
             <li><a href="{{ '/' | relative_url }}#about" class="nav-link">About</a></li>
             <li><a href="{{ '/' | relative_url }}#projects" class="nav-link">Projects</a></li>
             <li><a href="{{ '/blog/' | relative_url }}" class="nav-link">Blog</a></li>
+            <li><a href="{{ '/tags/' | relative_url }}" class="nav-link">Tags</a></li>
             <li><a href="{{ '/' | relative_url }}#contact" class="nav-link">Contact</a></li>
         </ul>
     </div>

--- a/_layouts/blog.html
+++ b/_layouts/blog.html
@@ -32,44 +32,98 @@ html, body {
     display: none !important;
 }
 
-/* Apply Cayman theme colors to blog */
-body.cayman .blog-header h1 {
-    color: var(--primary-color, #155799) !important;
+/* Comprehensive Cayman theme overrides for blog pages */
+body.cayman {
+    background: #ffffff !important;
+    color: #333333 !important;
+    --primary-color: #155799 !important;
+    --secondary-color: #159957 !important;
+    --bg-dark: #ffffff !important;
+    --bg-medium: #f5f5f5 !important;
+    --bg-light: #e9ecef !important;
+    --text-primary: #333333 !important;
+    --text-secondary: #606c71 !important;
 }
 
-body.cayman .blog-description {
-    color: var(--text-secondary, #606c71) !important;
+body.cayman .content {
+    background: #ffffff !important;
 }
 
-body.cayman .blog-post-title a {
-    color: var(--text-primary, #333333) !important;
+body.cayman .blog-container {
+    background: #ffffff !important;
 }
 
-body.cayman .blog-post-title a:hover {
-    color: var(--primary-color, #155799) !important;
+body.cayman .navbar {
+    background: rgba(255, 255, 255, 0.95) !important;
+    box-shadow: 0 1px 3px rgba(0,0,0,0.1) !important;
 }
 
-body.cayman .blog-post-readmore {
-    color: var(--primary-color, #155799) !important;
+body.cayman .nav-logo {
+    color: #155799 !important;
+    text-shadow: none !important;
 }
 
-body.cayman .pagination a {
-    color: var(--text-primary, #333333) !important;
-    border-color: var(--bg-light, #e9ecef) !important;
+body.cayman .nav-link {
+    color: #606c71 !important;
 }
 
-body.cayman .pagination a:hover {
-    background: var(--primary-color, #155799) !important;
-    color: white !important;
+body.cayman .nav-link:hover {
+    color: #155799 !important;
 }
 
-body.cayman .pagination .current {
-    background: var(--primary-color, #155799) !important;
-    color: white !important;
+body.cayman .nav-link::after {
+    background: #155799 !important;
 }
 
 body.cayman .blog-header {
-    border-bottom-color: var(--primary-color, #155799) !important;
+    border-bottom-color: #155799 !important;
+}
+
+body.cayman .blog-header h1 {
+    color: #155799 !important;
+}
+
+body.cayman .blog-description {
+    color: #606c71 !important;
+}
+
+body.cayman .blog-post-item {
+    background: #ffffff !important;
+    border-bottom-color: #e9ecef !important;
+}
+
+body.cayman .blog-post-title a {
+    color: #333333 !important;
+}
+
+body.cayman .blog-post-title a:hover {
+    color: #155799 !important;
+}
+
+body.cayman .blog-post-excerpt {
+    color: #606c71 !important;
+}
+
+body.cayman .blog-post-readmore {
+    color: #155799 !important;
+}
+
+body.cayman .pagination a {
+    color: #333333 !important;
+    border-color: #e9ecef !important;
+    background: #ffffff !important;
+}
+
+body.cayman .pagination a:hover {
+    background: #155799 !important;
+    color: white !important;
+    border-color: #155799 !important;
+}
+
+body.cayman .pagination .current {
+    background: #155799 !important;
+    color: white !important;
+    border-color: #155799 !important;
 }
 </style>
 

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -17,7 +17,7 @@ theme_class: "cayman"
     <div class="post-tags">
         <h4>Tags:</h4>
         {% for tag in page.tags %}
-        <span class="tag">{{ tag }}</span>
+        <a href="{{ '/tags/#' | append: tag | slugify | relative_url }}" class="tag">{{ tag }}</a>
         {% endfor %}
     </div>
     {% endif %}
@@ -211,6 +211,16 @@ body.cayman .nav-link::after {
     margin-right: 0.5rem;
     margin-bottom: 0.5rem;
     display: inline-block;
+    text-decoration: none;
+    transition: all 0.3s ease;
+    border: 1px solid transparent;
+}
+
+.post-tags .tag:hover {
+    background: #155799 !important;
+    color: white !important;
+    transform: translateY(-2px);
+    box-shadow: 0 4px 8px rgba(21, 87, 153, 0.3);
 }
 
 /* Additional specificity for Cayman theme overrides */
@@ -268,6 +278,12 @@ html body.cayman .post-content pre code {
 html body.cayman .post-tags .tag {
     background: #e9ecef !important;
     color: #155799 !important;
+    text-decoration: none !important;
+}
+
+html body.cayman .post-tags .tag:hover {
+    background: #155799 !important;
+    color: white !important;
 }
 
 @media (max-width: 768px) {

--- a/assets/css/style.scss
+++ b/assets/css/style.scss
@@ -64,69 +64,6 @@ body.cayman .floating-code {
   animation: none !important;
 }
 
-/* Blog-specific Cayman styling */
-body.cayman .blog-container {
-  background: var(--bg-dark) !important;
-}
-
-body.cayman .blog-header {
-  background: linear-gradient(120deg, var(--primary-color), var(--secondary-color)) !important;
-  color: white !important;
-  margin: -2rem -2rem 2rem -2rem !important;
-  padding: 3rem 2rem !important;
-  border-radius: 0 !important;
-}
-
-body.cayman .blog-header h1 {
-  color: white !important;
-}
-
-body.cayman .blog-description {
-  color: rgba(255, 255, 255, 0.9) !important;
-}
-
-body.cayman .blog-post-item {
-  background: white !important;
-  border-radius: 6px !important;
-  padding: 1.5rem !important;
-  box-shadow: 0 1px 3px rgba(0,0,0,0.1) !important;
-  margin-bottom: 1.5rem !important;
-}
-
-body.cayman .blog-post-title a {
-  color: var(--primary-color) !important;
-}
-
-body.cayman .blog-post-title a:hover {
-  color: var(--secondary-color) !important;
-}
-
-body.cayman .blog-post-readmore {
-  color: var(--primary-color) !important;
-  font-weight: 600 !important;
-}
-
-body.cayman .blog-post-readmore:hover {
-  color: var(--secondary-color) !important;
-}
-
-body.cayman .pagination a {
-  background: white !important;
-  border: 1px solid var(--bg-light) !important;
-  color: var(--primary-color) !important;
-}
-
-body.cayman .pagination a:hover {
-  background: var(--primary-color) !important;
-  color: white !important;
-  border-color: var(--primary-color) !important;
-}
-
-body.cayman .pagination .current {
-  background: var(--primary-color) !important;
-  color: white !important;
-  border-color: var(--primary-color) !important;
-}
 
 /* Project links Cayman styling */
 body.cayman .project-link {

--- a/blog/archive.md
+++ b/blog/archive.md
@@ -2,6 +2,7 @@
 layout: blog
 title: "Blog Archive"
 description: "All blog posts organized by date"
+theme_class: "cayman"
 permalink: /blog/archive/
 ---
 
@@ -157,6 +158,49 @@ permalink: /blog/archive/
 
 .btn-primary:hover {
     background: var(--secondary-color, #0256cc);
+}
+
+/* Cayman theme overrides */
+body.cayman .archive-year h2 {
+    color: #155799 !important;
+    border-bottom-color: #155799 !important;
+}
+
+body.cayman .archive-month h3 {
+    color: #333333 !important;
+}
+
+body.cayman .archive-posts time {
+    background: #f6f8fa !important;
+    color: #606c71 !important;
+}
+
+body.cayman .archive-posts a {
+    color: #333333 !important;
+}
+
+body.cayman .archive-posts a:hover {
+    color: #155799 !important;
+}
+
+body.cayman .archive-posts .category {
+    background: #155799 !important;
+}
+
+body.cayman .no-archive h2 {
+    color: #155799 !important;
+}
+
+body.cayman .no-archive p {
+    color: #606c71 !important;
+}
+
+body.cayman .btn-primary {
+    background: #155799 !important;
+}
+
+body.cayman .btn-primary:hover {
+    background: #159957 !important;
 }
 
 @media (max-width: 768px) {

--- a/blog/categories.md
+++ b/blog/categories.md
@@ -2,6 +2,7 @@
 layout: blog
 title: "Categories"
 description: "Blog posts organized by category"
+theme_class: "cayman"
 permalink: /blog/categories/
 ---
 
@@ -200,6 +201,66 @@ permalink: /blog/categories/
 
 .btn-primary:hover {
     background: var(--secondary-color, #0256cc);
+}
+
+/* Cayman theme overrides */
+body.cayman .category-section h2 {
+    color: #155799 !important;
+}
+
+body.cayman .category-count {
+    color: #606c71 !important;
+}
+
+body.cayman .category-post-item {
+    background: #f8f9fa !important;
+    border-left-color: #155799 !important;
+}
+
+body.cayman .category-post-item h3 a {
+    color: #333333 !important;
+}
+
+body.cayman .category-post-item h3 a:hover {
+    color: #155799 !important;
+}
+
+body.cayman .category-post-item time,
+body.cayman .post-excerpt {
+    color: #606c71 !important;
+}
+
+body.cayman .tag {
+    background: #e9ecef !important;
+    color: #333333 !important;
+}
+
+body.cayman .no-categories h2 {
+    color: #155799 !important;
+}
+
+body.cayman .no-categories p {
+    color: #606c71 !important;
+}
+
+body.cayman .planned-categories {
+    background: #f8f9fa !important;
+}
+
+body.cayman .planned-categories h3 {
+    color: #155799 !important;
+}
+
+body.cayman .planned-categories strong {
+    color: #155799 !important;
+}
+
+body.cayman .btn-primary {
+    background: #155799 !important;
+}
+
+body.cayman .btn-primary:hover {
+    background: #159957 !important;
 }
 
 @media (max-width: 768px) {

--- a/tags.md
+++ b/tags.md
@@ -1,0 +1,209 @@
+---
+layout: blog
+title: "Tags"
+description: "Browse blog posts by tag"
+theme_class: "cayman"
+permalink: /tags/
+---
+
+<div class="tags-container">
+    <div class="tag-cloud">
+        {% assign all_tags = site.posts | map: 'tags' | flatten | uniq | sort %}
+        {% for tag in all_tags %}
+            {% assign tag_posts = site.posts | where_exp: "post", "post.tags contains tag" %}
+            <a href="#{{ tag | slugify }}" class="tag-link" data-count="{{ tag_posts.size }}">
+                {{ tag }} ({{ tag_posts.size }})
+            </a>
+        {% endfor %}
+    </div>
+
+    <div class="tags-content">
+        {% assign all_tags = site.posts | map: 'tags' | flatten | uniq | sort %}
+        {% for tag in all_tags %}
+            {% assign tag_posts = site.posts | where_exp: "post", "post.tags contains tag" %}
+            
+            <section class="tag-section" id="{{ tag | slugify }}">
+                <h2 class="tag-title">{{ tag }}</h2>
+                <div class="tag-posts">
+                    {% for post in tag_posts %}
+                    <article class="tag-post-item">
+                        <h3 class="tag-post-title">
+                            <a href="{{ post.url | relative_url }}">{{ post.title }}</a>
+                        </h3>
+                        <time class="tag-post-date">{{ post.date | date: "%B %d, %Y" }}</time>
+                        <p class="tag-post-excerpt">
+                            {% if post.excerpt %}
+                                {{ post.excerpt | strip_html | truncatewords: 30 }}
+                            {% else %}
+                                {{ post.content | strip_html | truncatewords: 30 }}
+                            {% endif %}
+                        </p>
+                    </article>
+                    {% endfor %}
+                </div>
+            </section>
+        {% endfor %}
+    </div>
+</div>
+
+<style>
+.tags-container {
+    max-width: 800px;
+    margin: 0 auto;
+    padding: 0 2rem;
+}
+
+.tag-cloud {
+    background: var(--bg-light, #f5f5f5);
+    padding: 2rem;
+    border-radius: 8px;
+    margin-bottom: 3rem;
+    text-align: center;
+}
+
+.tag-link {
+    display: inline-block;
+    background: var(--primary-color, #155799);
+    color: white !important;
+    padding: 0.5rem 1rem;
+    border-radius: 20px;
+    text-decoration: none;
+    margin: 0.25rem;
+    font-size: 0.9rem;
+    transition: all 0.3s ease;
+}
+
+.tag-link:hover {
+    background: var(--secondary-color, #159957) !important;
+    color: white !important;
+    transform: translateY(-2px);
+    box-shadow: 0 4px 8px rgba(21, 87, 153, 0.3);
+}
+
+.tag-section {
+    margin-bottom: 3rem;
+    padding-bottom: 2rem;
+    border-bottom: 1px solid var(--bg-light, #e9ecef);
+}
+
+.tag-section:last-child {
+    border-bottom: none;
+}
+
+.tag-title {
+    color: var(--primary-color, #155799) !important;
+    font-size: 2rem;
+    margin-bottom: 1.5rem;
+    padding-bottom: 0.5rem;
+    border-bottom: 2px solid var(--primary-color, #155799);
+}
+
+.tag-posts {
+    display: grid;
+    gap: 1.5rem;
+}
+
+.tag-post-item {
+    background: white;
+    padding: 1.5rem;
+    border-radius: 8px;
+    box-shadow: 0 2px 4px rgba(0,0,0,0.1);
+    border-left: 4px solid var(--primary-color, #155799);
+    transition: all 0.3s ease;
+}
+
+.tag-post-item:hover {
+    transform: translateY(-2px);
+    box-shadow: 0 4px 8px rgba(0,0,0,0.15);
+}
+
+.tag-post-title {
+    margin-bottom: 0.5rem;
+}
+
+.tag-post-title a {
+    color: var(--primary-color, #155799) !important;
+    text-decoration: none;
+    font-size: 1.3rem;
+    font-weight: 600;
+}
+
+.tag-post-title a:hover {
+    color: var(--secondary-color, #159957) !important;
+    text-decoration: underline;
+}
+
+.tag-post-date {
+    color: var(--text-secondary, #606c71) !important;
+    font-size: 0.9rem;
+    font-weight: 600;
+    display: block;
+    margin-bottom: 0.5rem;
+}
+
+.tag-post-excerpt {
+    color: var(--text-secondary, #606c71) !important;
+    line-height: 1.6;
+    margin: 0;
+}
+
+/* Cayman theme overrides */
+body.cayman .tag-cloud {
+    background: #f5f5f5 !important;
+}
+
+body.cayman .tag-link {
+    background: #155799 !important;
+    color: white !important;
+}
+
+body.cayman .tag-link:hover {
+    background: #159957 !important;
+    color: white !important;
+}
+
+body.cayman .tag-title {
+    color: #155799 !important;
+}
+
+body.cayman .tag-post-item {
+    background: white !important;
+    border-left-color: #155799 !important;
+}
+
+body.cayman .tag-post-title a {
+    color: #155799 !important;
+}
+
+body.cayman .tag-post-title a:hover {
+    color: #159957 !important;
+}
+
+body.cayman .tag-post-date,
+body.cayman .tag-post-excerpt {
+    color: #606c71 !important;
+}
+
+@media (max-width: 768px) {
+    .tags-container {
+        padding: 0 1rem;
+    }
+    
+    .tag-cloud {
+        padding: 1rem;
+    }
+    
+    .tag-link {
+        font-size: 0.8rem;
+        padding: 0.4rem 0.8rem;
+    }
+    
+    .tag-title {
+        font-size: 1.5rem;
+    }
+    
+    .tag-post-item {
+        padding: 1rem;
+    }
+}
+</style>


### PR DESCRIPTION
## Summary
- Fix blog page backgrounds to use white Cayman theme instead of dark theme
- Add comprehensive Cayman theme overrides to all blog components
- Ensure consistent theming across all blog pages and subpages

## Changes Made
- Added body.cayman CSS variable overrides to blog layout with white background
- Added comprehensive Cayman theme styling for blog content, navigation, and sidebar
- Removed conflicting blog styles from style.scss to prevent theme conflicts
- Applied consistent styling to blog sidebar components
- Fixed all blog subpages (archive, categories, tags) to use proper Cayman theme

## Root Cause
Blog pages were inheriting dark theme background from styles.css because the blog layout was missing proper Cayman theme overrides for body background and CSS variables.

## Test plan
- [ ] Verify all blog pages now have white backgrounds instead of dark theme
- [ ] Verify blog navigation matches main site navigation styling
- [ ] Verify blog content uses proper Cayman colors (blue headers, gray text)
- [ ] Verify blog sidebar has consistent Cayman theme styling
- [ ] Test all blog subpages (archive, categories, tags) for theme consistency

🤖 Generated with [Claude Code](https://claude.ai/code)