### PR TITLE
Fix broken blog category links and enhance individual blog post themes

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -10,6 +10,7 @@ plugins:
   - jekyll-feed
   - jekyll-sitemap
   - jekyll-paginate
+  - jekyll-redirect-from
 
 # Blog configuration
 paginate: 5

--- a/_includes/post-meta.html
+++ b/_includes/post-meta.html
@@ -53,6 +53,15 @@
     font-style: italic;
 }
 
+/* Cayman theme overrides for post meta */
+body.cayman .post-meta {
+    color: #606c71 !important;
+}
+
+body.cayman .category {
+    background: #155799 !important;
+}
+
 @media (max-width: 768px) {
     .post-author,
     .read-time {

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -1,7 +1,34 @@
 ---
 layout: default
 theme_class: "cayman"
+custom_css: ""
 ---
+
+<style>
+/* Critical CSS overrides that must load after all other stylesheets */
+:root {
+    --primary-color: #155799 !important;
+    --secondary-color: #159957 !important;
+    --bg-dark: #ffffff !important;
+    --bg-medium: #f5f5f5 !important;
+    --bg-light: #e9ecef !important;
+    --text-primary: #333333 !important;
+    --text-secondary: #606c71 !important;
+}
+
+html,
+body,
+body.cayman {
+    background: #ffffff !important;
+    background-color: #ffffff !important;
+    color: #333333 !important;
+}
+
+main.content {
+    background: #ffffff !important;
+    background-color: #ffffff !important;
+}
+</style>
 
 <article class="blog-post">
     <header class="post-header">
@@ -26,6 +53,18 @@ theme_class: "cayman"
 </article>
 
 <style>
+/* Override root CSS variables for blog posts */
+html:has(body.cayman),
+:root:has(body.cayman) {
+    --primary-color: #155799 !important;
+    --secondary-color: #159957 !important;
+    --bg-dark: #ffffff !important;
+    --bg-medium: #f5f5f5 !important;
+    --bg-light: #e9ecef !important;
+    --text-primary: #333333 !important;
+    --text-secondary: #606c71 !important;
+}
+
 /* Hide hero section for blog posts */
 .hero {
     display: none !important;
@@ -37,14 +76,24 @@ body {
     min-height: auto !important;
 }
 
+body.cayman {
+    background: #ffffff !important;
+    background-color: #ffffff !important;
+    color: #333333 !important;
+}
+
 .content {
     padding-top: 100px; /* Account for navbar */
     min-height: auto !important;
+    background: #ffffff !important;
+    background-color: #ffffff !important;
 }
 
 /* Comprehensive Cayman theme overrides for individual blog posts */
-body.cayman {
+:root body.cayman,
+html body.cayman {
     background: #ffffff !important;
+    background-color: #ffffff !important;
     color: #333333 !important;
     --primary-color: #155799 !important;
     --secondary-color: #159957 !important;
@@ -224,12 +273,18 @@ body.cayman .nav-link::after {
 }
 
 /* Additional specificity for Cayman theme overrides */
-html body.cayman .content {
+html body.cayman,
+html body.cayman *,
+html body.cayman .content,
+html body.cayman main,
+html body.cayman main.content {
     background: #ffffff !important;
+    background-color: #ffffff !important;
 }
 
 html body.cayman .blog-post {
     background: #ffffff !important;
+    background-color: #ffffff !important;
 }
 
 html body.cayman .post-content * {

--- a/blog/categories.md
+++ b/blog/categories.md
@@ -4,6 +4,25 @@ title: "Categories"
 description: "Blog posts organized by category"
 theme_class: "cayman"
 permalink: /blog/categories/
+redirect_from:
+  - /categories-ai/
+  - /categories-security/
+  - /categories-kubernetes/
+  - /categories-tools/
+  - /categories-development/
+  - /categories-vscode/
+  - /categories-microsoft/
+  - /categories-productivity/
+  - /categories-devops/
+  - /blog-categories-ai/
+  - /blog-categories-security/
+  - /blog-categories-kubernetes/
+  - /blog-categories-tools/
+  - /blog-categories-development/
+  - /blog-categories-vscode/
+  - /blog-categories-microsoft/
+  - /blog-categories-productivity/
+  - /blog-categories-devops/
 ---
 
 <div class="categories-container">


### PR DESCRIPTION
## Summary
- Fix broken category URLs that were returning 404 errors
- Enhance individual blog post theme consistency with stronger CSS overrides
- Ensure all blog pages use proper Cayman theme styling

## Changes Made

### Broken Link Fixes
- Added `jekyll-redirect-from` plugin to _config.yml
- Set up redirects from broken URLs like `/categories-ai/` and `/blog-categories-ai/` to `/blog/categories/`
- Added comprehensive redirect mappings for all major categories (ai, security, kubernetes, tools, etc.)

### Enhanced Blog Post Theme Fixes
- Override root CSS variables directly in post layout for better theme consistency
- Add critical CSS overrides that load after all other stylesheets
- Target html, body, and main.content elements with stronger specificity
- Add Cayman theme overrides to post-meta include component
- Ensure white background takes precedence over dark theme styles

## Root Cause
1. **Broken Links**: Expected category URLs like `/categories-ai/` didn't exist, causing 404s
2. **Individual Blog Posts**: CSS specificity conflicts between dark theme base styles and Cayman overrides

## Test plan
- [ ] Verify broken category URLs now redirect to proper categories page
- [ ] Verify individual blog posts display with white background and proper Cayman theme
- [ ] Verify blog post navigation and content styling is consistent
- [ ] Test category links from sidebar and other navigation elements

🤖 Generated with [Claude Code](https://claude.ai/code)